### PR TITLE
Stabilize build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,16 +29,17 @@ jobs:
     parameters:
       ruby-version:
         type: string
-      fb-version:
+      gemfile:
         type: string
     executor:
       name: ruby
       tag: << parameters.ruby-version >>
-    environment:
-      FB_VERSION: << parameters.fb-version >>
     steps:
       - attach_workspace:
           at: ~/factory_trace
+      - run:
+          name: Use << parameters.gemfile >> as the Gemfile
+          command: bundle config --global gemfile << parameters.gemfile >>
       - run:
           name: Install the gems specified by the Gemfile
           command: bundle install
@@ -73,50 +74,17 @@ workflows:
                 "3.0",
                 "latest"
               ]
-              fb-version: [
-                "4.10",
-                "4.11",
-                "5.0",
-                "5.1",
-                "5.2",
-                "6.0",
-                "6.1",
-                "6.2"
+              gemfile: [
+                "gemfiles/fb_4_10.gemfile",
+                "gemfiles/fb_4_11.gemfile",
+                "gemfiles/fb_5_0.gemfile",
+                "gemfiles/fb_5_1.gemfile",
+                "gemfiles/fb_5_2.gemfile",
+                "gemfiles/fb_6_0.gemfile",
+                "gemfiles/fb_6_1.gemfile",
+                "gemfiles/fb_6_2.gemfile"
               ]
-            exclude:
-              - ruby-version: "3.0"
-                fb-version: "4.10"
-              - ruby-version: "3.0"
-                fb-version: "4.11"
-              - ruby-version: "3.0"
-                fb-version: "5.0"
-              - ruby-version: "3.0"
-                fb-version: "5.1"
-              - ruby-version: "3.0"
-                fb-version: "5.2"
-              - ruby-version: "3.0"
-                fb-version: "6.0"
-              - ruby-version: "3.0"
-                fb-version: "6.1"
-              - ruby-version: "3.0"
-                fb-version: "6.2"
-              - ruby-version: "latest"
-                fb-version: "4.10"
-              - ruby-version: "latest"
-                fb-version: "4.11"
-              - ruby-version: "latest"
-                fb-version: "5.0"
-              - ruby-version: "latest"
-                fb-version: "5.1"
-              - ruby-version: "latest"
-                fb-version: "5.2"
-              - ruby-version: "latest"
-                fb-version: "6.0"
-              - ruby-version: "latest"
-                fb-version: "6.1"
-              - ruby-version: "latest"
-                fb-version: "6.2"
-          name: build-ruby-<< matrix.ruby-version >>/fb-<< matrix.fb-version >>
+          name: build-ruby-<< matrix.ruby-version >>/fb-<< matrix.gemfile >>
 
   nightly:
     triggers:

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
-Gemfile.lock
+*.lock
 Gemfile.local
 
 # Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,10 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :test do
-  gem 'rspec_junit_formatter', '~> 0.4.1'
-end
-
 local_gemfile = 'Gemfile.local'
 
 if File.exist?(local_gemfile)
   eval(File.read(local_gemfile))
 else
-  gem 'factory_bot', ENV.fetch('FB_VERSION', '~> 5.0')
+  gem 'factory_bot', '~> 6.0'
 end

--- a/factory_trace.gemspec
+++ b/factory_trace.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.17.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
 end

--- a/gemfiles/fb_4_10.gemfile
+++ b/gemfiles/fb_4_10.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'factory_bot', '~> 4.10.0'
+
+gemspec path: '../'

--- a/gemfiles/fb_4_11.gemfile
+++ b/gemfiles/fb_4_11.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'factory_bot', '~> 4.11.0'
+
+gemspec path: '../'

--- a/gemfiles/fb_5_0.gemfile
+++ b/gemfiles/fb_5_0.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'factory_bot', '~> 5.0.0'
+
+gemspec path: '../'

--- a/gemfiles/fb_5_1.gemfile
+++ b/gemfiles/fb_5_1.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'factory_bot', '~> 5.1.0'
+
+gemspec path: '../'

--- a/gemfiles/fb_5_2.gemfile
+++ b/gemfiles/fb_5_2.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'factory_bot', '~> 5.2.0'
+
+gemspec path: '../'

--- a/gemfiles/fb_6_0.gemfile
+++ b/gemfiles/fb_6_0.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'factory_bot', '~> 6.0.0'
+
+gemspec path: '../'

--- a/gemfiles/fb_6_1.gemfile
+++ b/gemfiles/fb_6_1.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'factory_bot', '~> 6.1.0'
+
+gemspec path: '../'

--- a/gemfiles/fb_6_2.gemfile
+++ b/gemfiles/fb_6_2.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'factory_bot', '~> 6.2.0'
+
+gemspec path: '../'

--- a/spec/factory_trace/structures/factory_spec.rb
+++ b/spec/factory_trace/structures/factory_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe FactoryTrace::Structures::Factory do
-  subject(:factory) { described_class.new(names, traits, opts) }
+  subject(:factory) { described_class.new(names, traits, **opts) }
 
   let(:names) { ['user', 'person'] }
   let(:traits) { [FactoryTrace::Structures::Trait.new('special')] }


### PR DESCRIPTION
- Use double splat (**) 
- Create a separate `gemfile` for each version of FB
- Move `rspec_junit_formatter` to `gemspec`

Also, it will now be easier to run tests (on the local machine) for each FB version due to the usage of gemfiles instead of the constant (`FB_VERSION`).

```sh
BUNDLE_GEMFILE=gemfiles/fb_4_10.gemfile bundle exec rspec
```

No more need to run `bundle update factory_bot`.