### PR TITLE
[WIP] Work around `FactoryBot.reload`

### DIFF
--- a/lib/factory_trace.rb
+++ b/lib/factory_trace.rb
@@ -49,7 +49,7 @@ module FactoryTrace
       return unless configuration.enabled
 
       # This is required to exclude parent traits from +defined_traits+
-      FactoryBot.reload
+      # FactoryBot.reload
 
       if configuration.mode?(:full)
         Writers::ReportWriter.new(configuration.out, configuration).write(Processors::FindUnused.call(defined, used))

--- a/lib/factory_trace/helpers/converter.rb
+++ b/lib/factory_trace/helpers/converter.rb
@@ -20,6 +20,9 @@ module FactoryTrace
       #
       # @return [FactoryTrace::Structures::Factory]
       def factory(factory)
+        # Manually run compilation to define all traits.
+        # factory.compile if [:a, :b].include?(factory.name)
+
         FactoryTrace::Structures::Factory.new(
           factory.names.map(&:to_s),
           factory.defined_traits.map(&method(:trait)),

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -56,4 +56,28 @@ FactoryBot.define do
   trait :with_address do
     address { "address" }
   end
+
+  factory :a do
+    trait :a1 do
+      a1 { "a1" }
+    end
+
+    trait :a2 do
+      a2 { "a2" }
+    end
+  end
+
+  factory :b, parent: :a, class: "B" do
+    trait :b1 do
+      a1 { "b1" }
+    end
+  end
+end
+
+class A
+  attr_accessor :a1, :a2
+end
+
+class B < A
+  attr_accessor :b1
 end

--- a/spec/factory_trace/integration_tests/expected.txt
+++ b/spec/factory_trace/integration_tests/expected.txt
@@ -1,5 +1,5 @@
 total number of unique used factories & traits: 0
-total number of unique unused factories & traits: 12
+total number of unique unused factories & traits: 17
 unused factory user => spec/factories.rb:19
 unused trait with_phone of factory user => spec/factories.rb:22
 unused factory user_with_defaults => spec/factories.rb:26
@@ -11,4 +11,9 @@ unused factory company => spec/factories.rb:44
 unused trait with_manager of factory company => spec/factories.rb:45
 unused factory article, post => spec/factories.rb:50
 unused factory comment => spec/factories.rb:52
+unused factory a => spec/factories.rb:60
+unused trait a1 of factory a => spec/factories.rb:61
+unused trait a2 of factory a => spec/factories.rb:65
+unused factory b => spec/factories.rb:70
+unused trait b1 of factory b => spec/factories.rb:71
 unused global trait with_address => spec/factories.rb:56

--- a/spec/factory_trace/preprocessors/extract_defined_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_defined_spec.rb
@@ -35,7 +35,21 @@ RSpec.describe FactoryTrace::Preprocessors::ExtractDefined do
             ]
           ),
           FactoryTrace::Structures::Factory.new(["article", "post"], []),
-          FactoryTrace::Structures::Factory.new(["comment"], [], declaration_names: ["post"])
+          FactoryTrace::Structures::Factory.new(["comment"], [], declaration_names: ["post"]),
+          FactoryTrace::Structures::Factory.new(
+            ["a"],
+            [
+              FactoryTrace::Structures::Trait.new("a1"),
+              FactoryTrace::Structures::Trait.new("a2")
+            ]
+          ),
+          FactoryTrace::Structures::Factory.new(
+            ["b"],
+            [
+              FactoryTrace::Structures::Trait.new("b1")
+            ],
+            parent_name: "a"
+          )
         ],
         [
           FactoryTrace::Structures::Trait.new("with_address")

--- a/spec/factory_trace/processors/find_unused_spec.rb
+++ b/spec/factory_trace/processors/find_unused_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 0},
-          {code: :unused, value: 12},
+          {code: :unused, value: 17},
           {code: :unused, factory_names: ["user"]},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
@@ -22,6 +22,11 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -33,7 +38,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 1},
-          {code: :unused, value: 11},
+          {code: :unused, value: 16},
           {code: :unused, factory_names: ["user"]},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
@@ -44,6 +49,11 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -55,7 +65,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 1},
-          {code: :unused, value: 11},
+          {code: :unused, value: 16},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"]},
@@ -66,6 +76,11 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -77,7 +92,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 10},
+          {code: :unused, value: 15},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
@@ -87,6 +102,11 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -98,7 +118,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 10},
+          {code: :unused, value: 15},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
@@ -108,6 +128,12 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -119,7 +145,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 10},
+          {code: :unused, value: 15},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"]},
@@ -129,7 +155,12 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
-          {code: :unused, factory_names: ["comment"]}
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"}
         ])
       end
     end
@@ -140,7 +171,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 3},
-          {code: :unused, value: 9},
+          {code: :unused, value: 14},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
@@ -149,6 +180,11 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -160,7 +196,12 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 12},
-          {code: :unused, value: 0}
+          {code: :unused, value: 5},
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"}
         ])
       end
     end
@@ -171,13 +212,19 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 5},
-          {code: :unused, value: 7},
+          {code: :unused, value: 12},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["manager"]},
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -189,7 +236,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 4},
-          {code: :unused, value: 8},
+          {code: :unused, value: 13},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
@@ -197,6 +244,12 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -208,7 +261,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 10},
+          {code: :unused, value: 15},
           {code: :unused, factory_names: ["user"]},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
@@ -218,6 +271,12 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["manager"]},
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -229,12 +288,18 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 6},
-          {code: :unused, value: 6},
+          {code: :unused, value: 11},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -246,7 +311,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 4},
-          {code: :unused, value: 8},
+          {code: :unused, value: 13},
           {code: :unused, factory_names: ["admin"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
@@ -254,7 +319,12 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
-          {code: :unused, factory_names: ["comment"]}
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["a"]},
+          {code: :unused, factory_names: ["a"], trait_name: "a1"},
+          {code: :unused, factory_names: ["a"], trait_name: "a2"},
+          {code: :unused, factory_names: ["b"]},
+          {code: :unused, factory_names: ["b"], trait_name: "b1"}
         ])
       end
     end


### PR DESCRIPTION
```ruby
factory :a do
  trait :a1 do
    a1 { "a1" }
  end

  trait :a2 do
    a2 { "a2" }
  end
end

factory :b, parent: :a, class: "B" do
  trait :b1 do
    b1 { "b1" }
  end
end
```

```ruby
build(:b, :a1)
```

```sh
unused trait `:a2` of factory `:a`
unused trait `:b1` of factory `:b`
```